### PR TITLE
Version regex is too restrictive

### DIFF
--- a/res/schema.json
+++ b/res/schema.json
@@ -27,7 +27,7 @@
             "version": {
                 "description": "The semantic version number.",
                 "type": "string",
-                "pattern": "^\\d+\\.\\d+\\.\\d+(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$"
+                "pattern": "^\\d+\\.\\d+\\.\\d+(?:([A-Za-z]+([0-9A-Za-z.-]+)*)|(-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$"
             }
         },
         "required": ["name", "sha1", "url", "version"]


### PR DESCRIPTION
The version regex present in `res/schema.json` invalidates versions that follow semantic versioning if they do not include a `-` character between the version and any stability qualifiers.

While semver.org does specify that any stability or metadata information MAY presented following such a character, in practice, most libraries do not use the character. (E.g. PHP itself, PHPUnit, most pecl extensions, etc.). In fact, the PHP function `version_compare` is able to use either with or without a dash as well.

Essentially, I'd like to see each of `1.0.0-beta1`, `1.0.0-b1`, `1.0.0beta1`, and `1.0.0b1` validate under the schema. I'll prepare a PR shortly. 
