### PR TITLE
Upgrade herrera-io/json dependency to 2.* version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "herrera-io/json": "1.*",
+        "herrera-io/json": "2.*",
         "herrera-io/version": "1.*"
     },
     "require-dev": {

--- a/src/lib/Herrera/Phar/Update/Manifest.php
+++ b/src/lib/Herrera/Phar/Update/Manifest.php
@@ -2,10 +2,10 @@
 
 namespace Herrera\Phar\Update;
 
-use Herrera\Json\Json;
 use Herrera\Version\Comparator;
 use Herrera\Version\Parser;
 use Herrera\Version\Version;
+use KHerGe\JSON\JSON;
 
 /**
  * Manages the contents of an updates manifest file.
@@ -87,7 +87,7 @@ class Manifest
      */
     public static function load($json)
     {
-        $j = new Json();
+        $j = new JSON();
 
         return self::create($j->decode($json), $j);
     }
@@ -101,7 +101,7 @@ class Manifest
      */
     public static function loadFile($file)
     {
-        $json = new Json();
+        $json = new JSON();
 
         return self::create($json->decodeFile($file), $json);
     }

--- a/src/tests/Herrera/Phar/Update/ManifestTest.php
+++ b/src/tests/Herrera/Phar/Update/ManifestTest.php
@@ -3,10 +3,10 @@
 namespace Herrera\Phar\Update\Tests;
 
 use Herrera\Phar\Update\Manifest;
-use Herrera\Json\Exception\JsonException;
 use Herrera\Phar\Update\Update;
 use Herrera\PHPUnit\TestCase;
 use Herrera\Version\Parser;
+use KHerGe\JSON\Exception\Exception as JSONException;
 
 class ManifestTest extends TestCase
 {
@@ -77,7 +77,7 @@ class ManifestTest extends TestCase
 
         try {
             $updates = Manifest::load($data)->getUpdates();
-        } catch (JsonException $exception) {
+        } catch (JSONException $exception) {
             print_r($exception->getErrors());
             throw $exception;
         }
@@ -111,7 +111,7 @@ class ManifestTest extends TestCase
 
         try {
             $updates = Manifest::loadFile($file)->getUpdates();
-        } catch (JsonException $exception) {
+        } catch (JSONException $exception) {
             print_r($exception->getErrors());
             throw $exception;
         }


### PR DESCRIPTION
This PR upgrades `herrera-io/json` dependency version to `2.*` branch.

## Why?

With current sticking to `1.*` version this project creates problems in dependencies resolving.

For example (`composer.json`):
```json
{
  "require-dev": {
    "composer/composer": "~1.6",
    "phpdocumentor/phpdocumentor": "~2.9"
  }
}
```
These are the latest versions of Composer and phpDocumentor at the moment. But Composer won't resolve this, because [`phpdocumentor/phpdocumentor` requires this project](https://github.com/phpDocumentor/phpDocumentor2/blob/v2.9.0/composer.json#L31), and this project [requires `herrera-io/json` to be `1.*`](https://github.com/kherge-abandoned/php-phar-update/blob/2.0.0/composer.json#L19), and that one [requires `justinrainbow/json-schema` to be `>=1.0,<2.0-dev`](https://github.com/kherge-php/json/blob/1.0.3/composer.json#L20). Which is incompatible with [requirement of `composer/composer` (`justinrainbow/json-schema` to be `^3.0 || ^4.0 || ^5.0`)](https://github.com/composer/composer/blob/1.6.3/composer.json#L26).

The only possible way to resolve this at the moment is to downgrade `composer/composer` to `~1.3` which [considers `1.*` versions of `justinrainbow/json-schema`](https://github.com/composer/composer/blob/1.3.3/composer.json#L26).

## Solution

Upgrading `herrera-io/json` to `2.*` branch [will require a `^4.1` of `justinrainbow/json-schema`](https://github.com/kherge-php/json/blob/2.1.0/composer.json#L46), which will cause much less problems in transitive dependencies.